### PR TITLE
GitHub 프로젝트 API 정보 가져오기 및 Swagger UI 추가하라

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,17 +25,18 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/terminus": "^10.2.3",
+    "cross-env": "^7.0.3",
     "nestjs-octokit": "^0.2.0",
     "octokit": "^3.1.2",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1",
-    "cross-env": "^7.0.3"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
     "@nestjs/config": "^3.2.1",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@octokit/graphql": "^8.0.1",
     "@swc/core": "^1.4.11",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -14,13 +14,90 @@ export class AppController {
     return this.appService.getHello();
   }
 
-  @Get('/octo')
+  @Get('/login')
   async getOctokit() {
-    const response = await this.octokitService.graphql(`{
-      viewer {
-        login
+    const response = (
+      await this.octokitService.rest.search.users({ q: 'jihwooon' })
+    ).data.items[0]?.login;
+
+    return response;
+  }
+
+  @Get('/projects')
+  async getProjects() {
+    const response = await this.octokitService.graphql(
+      `query project ($login: String! $project: Int!) {
+      user (login: $login) {
+                  projectV2(number: $project) {
+                    id
+                    items(first: 3) {
+                      nodes {
+                      fieldValues(first:20){
+                          nodes {
+                          __typename
+                          ... on ProjectV2ItemFieldUserValue {
+                              field {
+                              ...on ProjectV2Field {
+                                  name
+                              }
+                              }
+                              users(first: 5) {
+                              nodes {
+                                  ...on ProfileOwner {
+                                      name
+                                      login
+                                  }
+                              }
+                              }
+                          }
+                          ... on ProjectV2ItemFieldDateValue {
+                              field {
+                              ... on ProjectV2Field {
+                                  name
+                              }
+                              }
+                              date
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                              field {
+                              ... on ProjectV2Field {
+                                  name
+                              }
+                              }
+                              number
+                          }
+                          ... on ProjectV2ItemFieldTextValue {
+                              field {
+                              ... on ProjectV2Field {
+                                  name
+                              }
+                              }
+                              text
+                              }
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                              field {
+                              ... on ProjectV2SingleSelectField {
+                                  name
+                              }
+                              }
+                              name
+
+                              }
+                          ... on ProjectV2ItemFieldDateValue {
+                              date
+                              }
+                          }
+                      }
+                  }
+              }
+          }
       }
-    }`);
+  }`,
+      {
+        login: 'jihwooon',
+        project: 23,
+      },
+    );
 
     return response;
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     container_name: web
     image: jihwooon/devops-platform-frontend
     build:
-      context: ./apps/web
-      dockerfile: ./Dockerfile
+      context: .
+      dockerfile: ./apps/web/Dockerfile
     restart: always
     ports:
       - 3000:3000
@@ -16,13 +16,24 @@ services:
     container_name: api
     image: jihwooon/devops-platform-backend
     build:
-      context: ./apps/api
-      dockerfile: ./Dockerfile
+      context: .
+      dockerfile: ./apps/api/Dockerfile
     restart: always
     ports:
       - 3031:3031
     networks:
       - app_network
+  swagger:
+    image: swaggerapi/swagger-ui
+    container_name: openapi
+    ports:
+    - 8080:8080
+    environment:
+     - URLS_PRIMARY_NAME=agenta
+     - "URLS=[{ url: 'docs/openapi.yaml', name: 'agent' }]"
+     - SUPPORTED_SUBMIT_METHODS=['get']
+    volumes:
+      - ./docs:/usr/share/nginx/html/docs
 
 # Define a network, which allows containers to communicate
 # with each other, by using their container name as a hostname

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: Reviews
+  version: 1.0.0
+servers:
+- url: https://farmstall.designapis.com/v1
+paths:
+  /reviews:
+    get:
+      description: Get a bunch of reviews
+      parameters:
+      - name: maxRating
+        description: |
+          Filter the reviews
+          by the maximum rating
+        in: query
+        schema:
+          type: number
+      responses:
+        200:
+          description: A bunch of reviews
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    uuid:
+                      type: string
+                      pattern: '^[0-9a-fA-F\-]{36}$'
+                    message:
+                      type: string
+                    rating:
+                      type: integer
+                      minimum: 1
+                      maximum: 5
+                    userId:
+                      type: string
+                      pattern: '^[0-9a-fA-F\-]{36}$'
+                      nullable: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@nestjs/testing':
         specifier: ^10.0.0
         version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)
+      '@octokit/graphql':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@swc/core':
         specifier: ^1.4.11
         version: 1.4.11
@@ -2191,6 +2194,14 @@ packages:
       universal-user-agent: 6.0.1
     dev: false
 
+  /@octokit/endpoint@10.0.0:
+    resolution: {integrity: sha512-emBcNDxBdC1y3+knJonS5zhUB/CG6TihubxM2U1/pG/Z1y3a4oV0Gzz3lmkCvWWQI6h3tqBAX9MgCBFp+M68Jw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 12.6.0
+      universal-user-agent: 7.0.2
+    dev: true
+
   /@octokit/endpoint@9.0.4:
     resolution: {integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==}
     engines: {node: '>= 18'}
@@ -2207,6 +2218,15 @@ packages:
       '@octokit/types': 12.6.0
       universal-user-agent: 6.0.1
     dev: false
+
+  /@octokit/graphql@8.0.1:
+    resolution: {integrity: sha512-lLDb6LhC1gBj2CxEDa5Xk10+H/boonhs+3Mi6jpRyetskDKNHe6crMeKmUE2efoLofMP8ruannLlCUgpTFmVzQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 9.0.1
+      '@octokit/types': 12.6.0
+      universal-user-agent: 7.0.2
+    dev: true
 
   /@octokit/oauth-app@6.1.0:
     resolution: {integrity: sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==}
@@ -2240,7 +2260,6 @@ packages:
 
   /@octokit/openapi-types@20.0.0:
     resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
-    dev: false
 
   /@octokit/plugin-paginate-graphql@4.0.1(@octokit/core@5.1.0):
     resolution: {integrity: sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==}
@@ -2303,6 +2322,13 @@ packages:
       once: 1.4.0
     dev: false
 
+  /@octokit/request-error@6.0.2:
+    resolution: {integrity: sha512-WtRVpoHcNXs84+s9s/wqfHaxM68NGMg8Av7h59B50OVO0PwwMx+2GgQ/OliUd0iQBSNWgR6N8afi/KjSHbXHWw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 12.6.0
+    dev: true
+
   /@octokit/request@8.2.0:
     resolution: {integrity: sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==}
     engines: {node: '>= 18'}
@@ -2313,11 +2339,20 @@ packages:
       universal-user-agent: 6.0.1
     dev: false
 
+  /@octokit/request@9.0.1:
+    resolution: {integrity: sha512-kL+cAcbSl3dctYLuJmLfx6Iku2MXXy0jszhaEIjQNaCp4zjHXrhVAHeuaRdNvJjW9qjl3u1MJ72+OuBP0YW/pg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 10.0.0
+      '@octokit/request-error': 6.0.2
+      '@octokit/types': 12.6.0
+      universal-user-agent: 7.0.2
+    dev: true
+
   /@octokit/types@12.6.0:
     resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
     dependencies:
       '@octokit/openapi-types': 20.0.0
-    dev: false
 
   /@octokit/webhooks-methods@4.1.0:
     resolution: {integrity: sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==}
@@ -9852,6 +9887,10 @@ packages:
   /universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: false
+
+  /universal-user-agent@7.0.2:
+    resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
+    dev: true
 
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}


### PR DESCRIPTION
- docker-compose.yml 업데이트: - 빌드 컨텍스트를 프로젝트 루트로 변경 (./apps/web, ./apps/api 대신) - 별도의 네트워크 설정 제거 (필요하지 않음)
- Swagger UI 도커 이미지 추가: - API 문서를 시각적으로 확인할 수 있는 Swagger UI 도입 - `openapi.yaml` 파일 참조하여 문서 자동 생성 - 8080 포트에 Swagger UI 노출