### PR TITLE
API 테스트 코드 작성 및 Mock 객체 활용하라

### DIFF
--- a/apps/api/src/issue/issue.controller.spec.ts
+++ b/apps/api/src/issue/issue.controller.spec.ts
@@ -1,18 +1,83 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { OctokitService } from 'nestjs-octokit';
+import { describe } from 'vitest';
 import { IssueController } from './issue.controller';
 
-describe('OctokitController', () => {
+describe('IssueController', () => {
   let controller: IssueController;
+  let fakeService: Partial<OctokitService>;
 
   beforeEach(async () => {
+    fakeService = {
+      rest: {
+        users: {
+          getAuthenticated: () => {
+            return Promise.resolve({
+              data: {
+                login: 'github-username',
+              },
+            });
+          },
+        },
+        repos: {
+          get: () => {
+            return Promise.resolve({
+              data: {
+                name: 'github-repo',
+              },
+            });
+          },
+        },
+        issues: {
+          get: () => {
+            return Promise.resolve({
+              data: {
+                title: 'issue-title',
+                body: 'issue-body',
+              },
+            });
+          },
+        },
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [IssueController],
+      providers: [
+        {
+          provide: OctokitService,
+          useValue: fakeService,
+        },
+      ],
     }).compile();
 
     controller = module.get<IssueController>(IssueController);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('Github 로그인 정보를 호출 시', () => {
+    it('해당 로그인 아이디를 리턴한다', async () => {
+      const login = await controller.getLogin();
+
+      expect(login).toBe('github-username');
+    });
+  });
+
+  describe('Github Repo 정보를 검색 시', () => {
+    it('해당 저장소의 이름을 리턴한다', async () => {
+      const repoName = await controller.getRepo('github-repo');
+
+      expect(repoName).toBe('github-repo');
+    });
+  });
+
+  describe('Github Repo 이름과 이슈 번호가 주어지면', () => {
+    it('해당 이슈의 제목과 내용을 리턴한다', async () => {
+      const issue = await controller.getIssues('1', 'github-repo');
+
+      expect(issue).toEqual({
+        title: 'issue-title',
+        body: 'issue-body',
+      });
+    });
   });
 });

--- a/apps/api/test/issue.e2e-spec.ts
+++ b/apps/api/test/issue.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { describe, it } from 'vitest';
+import { AppModule } from '../src/app.module';
+
+describe('IssueController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    await app.init();
+  });
+
+  describe('/git/login (GET)', () => {
+    it('should return the response body and status code', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/git/login')
+        .set('Authorization', `Bearer ${process.env.GITHUB_AUTH_TOKEN}`);
+
+      expect(response.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
- OctokitService 의존성 mock 객체 사용을 사용했습니다.
- 각 메서드에 테스트 케이스를 추가하였습니다.
  - 로그인 정보 조회 테스트 (getLogin)
  - 저장소 정보 조회 테스트 (getRepo)
  - 이슈 정보 조회 테스트 (getIssues)