### PR TITLE
프로덕션 배포 워크플로우 분리하라

### DIFF
--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -2,7 +2,9 @@ name: devops-plateform-frontend
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - "develop/**"
+      - "release/**"
     paths:
       - "apps/web/**"
 

--- a/.github/workflows/server-deploy.yaml
+++ b/.github/workflows/server-deploy.yaml
@@ -2,7 +2,9 @@ name: devops-plateform-server
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - "develop/**"
+      - "release/**"
     paths:
       - "apps/api/**"
 


### PR DESCRIPTION
- 기존 frontend.yaml 과 server.yaml 워크플로우 파일을 각각 frontend-deploy.yaml 과 server-deploy.yaml 파일로 분리
- 트리거 조건 변경: develop 브랜치 대신 develop/** 와 release/** 패턴 사용