### PR TITLE
API 서버 Docker 이미지 헬스 체크 및 모듈 분리

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -53,5 +53,5 @@ USER nestjs
 # Copy the app folder
 COPY --from=installer /app .
 
-HEALTHCHECK CMD curl --fail http://localhost:3001/health || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:3031/health || exit 1
 CMD node apps/api/dist/src/main.js

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,17 +1,14 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TerminusModule } from '@nestjs/terminus';
 import { OctokitModule } from 'nestjs-octokit';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { HealthController } from './health/health.controller';
+import { HealthModule } from './health/health.module';
 import { IssueController } from './issue/issue.controller';
 
 @Module({
   imports: [
-    TerminusModule,
-    HttpModule,
+    HealthModule,
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: `.env.${process.env.NODE_ENV}`,
@@ -27,7 +24,7 @@ import { IssueController } from './issue/issue.controller';
       },
     }),
   ],
-  controllers: [AppController, HealthController, IssueController],
+  controllers: [AppController, IssueController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -3,20 +3,28 @@ import {
   HealthCheck,
   HealthCheckService,
   HttpHealthIndicator,
+  MemoryHealthIndicator,
 } from '@nestjs/terminus';
 
-@Controller('health')
+@Controller()
 export class HealthController {
   constructor(
-    private health: HealthCheckService,
-    private http: HttpHealthIndicator,
+    private readonly health: HealthCheckService,
+    private readonly memory: MemoryHealthIndicator,
+    private readonly http: HttpHealthIndicator,
   ) {}
 
-  @Get()
+  @Get('health')
+  checkHealth() {
+    return 'ok';
+  }
+
+  @Get('status')
   @HealthCheck()
   check() {
     return this.health.check([
-      () => this.http.pingCheck('nestjs-docs', 'https://docs.nestjs.com'),
+      () => this.memory.checkHeap('memory_heap', 150 * 1024 * 1024),
+      () => this.http.pingCheck('server-api', 'http://localhost:3031'),
     ]);
   }
 }

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,0 +1,10 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+
+@Module({
+  imports: [TerminusModule, HttpModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}


### PR DESCRIPTION
- Dockerfile
  - 헬스 체크 엔드포인트 포트 수정 (3001 -> 3031)
- app.module.ts
  - HealthModule 추가 import
  - HealthModule 및 HttpModule 로 이전의 TerminusModule 기능 분리
  - HealthController 제외 컨트롤러 목록 업데이트
- health/health.controller.ts
  - 경로 설정: @Controller() (기존 @Controller('health'))
  - 새로운 헬스 체크 API 추가 (/health): 간단한 문자열 응답
  - 기존 헬스 체크 API (/status) 유지
  - 새로운 메모리 헬스 체크 추가 (checkHeap)
  - 의존성 주입 방식 변경 (private health: HealthCheckService -> private readonly health: HealthCheckService)
- health/health.module.ts: (새로운 파일)
  - HealthModule 생성
  - 필요한 모듈 (TerminusModule, HttpModule) import
  - HealthController 등록