### PR TITLE
서버 배포 워크플로우에 Docker Buildx 사용 및 플랫폼 지정 추가하라

### DIFF
--- a/.github/workflows/server-deploy.yaml
+++ b/.github/workflows/server-deploy.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Build with pnpm
         run: pnpm build
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -49,5 +52,6 @@ jobs:
         with:
           context: .
           file: ./apps/api/Dockerfile
+          platforms: linux/amd64
           push: true
           tags: ${{env.NAME}}/${{env.REPO}}:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   api:
     container_name: devops-platform-api
     image: jihwooon/devops-platform-backend
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./apps/api/Dockerfile


### PR DESCRIPTION
- Docker Buildx 사용 설정 (docker/setup-buildx-action@v2)
- 빌드 플랫폼을 linux/amd64 로 지정 (.github/workflows/server-deploy.yaml)
- docker-compose.yml 파일에서도 api 서비스의 플랫폼을 linux/amd64 로 명시적으로 설정했습니다.