### PR TITLE
Dev와 Prod 포트 분리를 하라

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -53,5 +53,5 @@ USER nestjs
 # Copy the app folder
 COPY --from=installer /app .
 
-HEALTHCHECK CMD curl --fail http://localhost:3031/health || exit 1
-CMD node apps/api/dist/src/main.js
+HEALTHCHECK CMD curl --fail http://localhost:30031/health || exit 1
+CMD pnpm run prod

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "start": "cross-env NODE_ENV=development nest start",
     "dev": "cross-env NODE_ENV=development nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "prod": "cross-env NODE_ENV=prod node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/api/src/config/settings.ts
+++ b/apps/api/src/config/settings.ts
@@ -1,0 +1,1 @@
+export const PORT = process.env.PORT ?? 3031;

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -24,7 +24,7 @@ export class HealthController {
   check() {
     return this.health.check([
       () => this.memory.checkHeap('memory_heap', 150 * 1024 * 1024),
-      () => this.http.pingCheck('server-api', 'http://localhost:3031'),
+      () => this.http.pingCheck('server-api', 'http://localhost:30031/health'),
     ]);
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,8 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { PORT } from './config/settings';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3031);
+  await app.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+  });
 }
 bootstrap();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       dockerfile: ./apps/api/Dockerfile
     restart: always
     ports:
-      - 3031:3031
+      - 30031:30031
     env_file:
       - ./apps/api/.env.prod
     environment:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo run dev --parallel",
+    "prod":"turbo run prod --parallel",
     "lint": "turbo lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "clean": "turbo run clean",

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,10 @@
       "cache": false,
       "persistent": true
     },
+    "prod": {
+      "cache": false,
+      "persistent": true
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
- apps/api/src/config/settings.ts 파일을 생성하여 PORT 설정을 위한 상수를 정의했습니다.
- apps/api/src/main.ts 파일을 다음과 같이 수정했습니다.
  - settings.ts 에서 PORT를 가져옴
  - app.listen() 메서드에서 PORT를 직접 지정하는 대신 정의된 PORT 상수 사용
  - 서버 실행 시 포트 정보를 로그로 출력